### PR TITLE
Load account from file or config; local cluster test

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -35,7 +35,7 @@ use {
     std::{
         cmp, env,
         sync::{
-            atomic::{AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Arc, RwLock,
         },
         thread::{self, Builder, JoinHandle},
@@ -418,6 +418,7 @@ impl BankingStage {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_test_generating_scheduler(
+        exit: Arc<AtomicBool>,
         cluster_info: &Arc<ClusterInfo>,
         poh_recorder: &Arc<RwLock<PohRecorder>>,
         non_vote_receiver: BankingPacketReceiver,
@@ -529,7 +530,7 @@ impl BankingStage {
         bank_thread_hdls.push(
             Builder::new()
                 .name("solBanknSched".to_string())
-                .spawn(move || scheduler.run())
+                .spawn(move || scheduler.run(&exit))
                 .unwrap(),
         );
         (0..num_threads.saturating_sub(2)).for_each(|id| {

--- a/core/src/banking_stage/consume_banking_worker.rs
+++ b/core/src/banking_stage/consume_banking_worker.rs
@@ -57,7 +57,13 @@ impl ConsumeBankingWorker {
                 transactions,
                 retryable_indexes,
             };
-            self.sender.send(finished_work).unwrap();
+            match self.sender.send(finished_work) {
+                Ok(_) => (),
+                Err(e) => {
+                    error!("Error sending finished work: {:?}", e);
+                    break;
+                }
+            }
         }
     }
 

--- a/core/src/banking_stage/test_scheduler.rs
+++ b/core/src/banking_stage/test_scheduler.rs
@@ -13,6 +13,7 @@ use {
         leader_slot_banking_stage_metrics::LeaderSlotMetricsTracker,
     },
     crossbeam_channel::{Receiver, Sender},
+    std::sync::{atomic::AtomicBool, Arc},
 };
 
 pub struct TestScheduler {
@@ -45,10 +46,14 @@ impl TestScheduler {
         }
     }
 
-    pub fn run(mut self) {
+    pub fn run(mut self, exit: &Arc<AtomicBool>) {
         let mut slot_metrics_tracker = LeaderSlotMetricsTracker::new(0);
         let mut rng = rand::thread_rng();
         loop {
+            if exit.load(std::sync::atomic::Ordering::Relaxed) {
+                debug!("TestScheduler exiting");
+                break;
+            }
             let (_action, decision) = self
                 .decision_maker
                 .make_consume_or_forward_decision(&mut slot_metrics_tracker);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2536,6 +2536,7 @@ impl ReplayStage {
         replay_result_vec: &[ReplaySlotFromBlockstore],
         prioritization_fee_cache: &PrioritizationFeeCache,
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        my_pubkey: &Pubkey,
     ) -> bool {
         // TODO: See if processing of blockstore replay results and bank completion can be made thread safe.
         let mut did_complete_bank = false;
@@ -2676,6 +2677,15 @@ impl ReplayStage {
                 }
                 bank_complete_time.stop();
 
+                if bank.collector_id() != my_pubkey {
+                    debug!("{my_pubkey:?} replay stats slot: {} with total transactions {}, shreds {}, time {}",
+                        bank.slot(),
+                        r_replay_progress.num_txs,
+                        r_replay_progress.num_shreds,
+                        r_replay_stats.replay_elapsed,
+                    );
+                }
+
                 r_replay_stats.report_stats(
                     bank.slot(),
                     r_replay_progress.num_txs,
@@ -2797,6 +2807,7 @@ impl ReplayStage {
                 &replay_result_vec,
                 prioritization_fee_cache,
                 purge_repair_slot_counter,
+                my_pubkey,
             )
         } else {
             false

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -178,7 +178,13 @@ pub struct ValidatorConfig {
     pub runtime_config: RuntimeConfig,
     pub replay_slots_concurrently: bool,
     pub banking_trace_dir_byte_limit: banking_trace::DirByteLimit,
-    pub test_generating_scheduler_accounts_path: Option<String>,
+    pub test_generating_info: Option<TestGenerator>,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestGenerator {
+    pub test_generating_scheduler_accounts_path: String,
+    pub starting_keypairs: Arc<Vec<Keypair>>,
 }
 
 impl Default for ValidatorConfig {
@@ -242,7 +248,7 @@ impl Default for ValidatorConfig {
             runtime_config: RuntimeConfig::default(),
             replay_slots_concurrently: false,
             banking_trace_dir_byte_limit: 0,
-            test_generating_scheduler_accounts_path: None,
+            test_generating_info: None,
         }
     }
 }
@@ -1070,7 +1076,7 @@ impl Validator {
             banking_tracer,
             tracer_thread,
             tpu_enable_udp,
-            config.test_generating_scheduler_accounts_path.clone(),
+            config.test_generating_info.clone(),
         );
 
         datapoint_info!(

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -65,9 +65,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
         banking_trace_dir_byte_limit: config.banking_trace_dir_byte_limit,
-        test_generating_scheduler_accounts_path: config
-            .test_generating_scheduler_accounts_path
-            .clone(),
+        test_generating_info: config.test_generating_info.clone(),
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4761,6 +4761,7 @@ impl Bank {
                 *err_count,
                 *err_count + executed_with_successful_result_count
             );
+            debug!("{error_counters:?}");
         }
         LoadAndExecuteTransactionsOutput {
             loaded_transactions,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -13,7 +13,10 @@ use {
         system_monitor_service::SystemMonitorService,
         tower_storage,
         tpu::DEFAULT_TPU_COALESCE_MS,
-        validator::{is_snapshot_config_valid, Validator, ValidatorConfig, ValidatorStartProgress},
+        validator::{
+            is_snapshot_config_valid, TestGenerator, Validator, ValidatorConfig,
+            ValidatorStartProgress,
+        },
     },
     solana_gossip::{cluster_info::Node, legacy_contact_info::LegacyContactInfo as ContactInfo},
     solana_ledger::blockstore_options::{
@@ -1452,9 +1455,12 @@ pub fn main() {
     }
 
     configure_banking_trace_dir_byte_limit(&mut validator_config, &matches);
-    validator_config.test_generating_scheduler_accounts_path = matches
+    validator_config.test_generating_info = matches
         .value_of("test_generating_scheduler_accounts_path")
-        .map(|path| path.to_string());
+        .map(|path| TestGenerator {
+            test_generating_scheduler_accounts_path: path.to_string(),
+            starting_keypairs: Arc::new(vec![]),
+        });
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {


### PR DESCRIPTION
More specifically the changes are:

1. Ability to either load accounts from file or hard coded from ValidatorConfig
2. Some fixes to make validator exit cleaner
3. Local Cluster test to run a couple nodes for 30 seconds to test block creation/replay
4. Additional Test scenario where we allocate accounts
5. Few additional debug messages